### PR TITLE
chore: modify docker build to support Arm

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,9 +8,19 @@ jobs:
       - uses: mstachniuk/ci-skip@v1
         with:
           fail-fast: true
-      - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
         with:
-          name: cinwell/notea
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          tags: cinwell/notea:latest
+          platforms: linux/amd64,linux/arm64
+          push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Building the code
-FROM mhart/alpine-node AS builder
+FROM node:alpine AS builder
 
 WORKDIR /app
 
@@ -14,7 +14,7 @@ RUN yarn install --production --frozen-lockfile
 
 
 # Stage 2: And then copy over node_modules, etc from that stage to the smaller base image
-FROM mhart/alpine-node:base as production
+FROM node:alpine as production
 
 WORKDIR /app
 


### PR DESCRIPTION
Hi,

I've made some minor changes to the Docker build to support Arm platforms. This has meant changing the base Docker image to one that provides an Arm variant and updating the GH Actions configuration to build for both amd64 and arm64. This should address #9.

I've tested the build on my local machine and that works. For the Actions config, I've followed [the official docs](https://github.com/docker/build-push-action/blob/master/docs/advanced/multi-platform.md).

What do you think about this?

Thanks.