### PR TITLE
fix netlify link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 - [Next.js](https://nextjs.org/)
 - [S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html)
-- [Vercel](https://vercel.com/), [Netlify](netlify.com) or [Docker](https://www.docker.com/)
+- [Vercel](https://vercel.com/), [Netlify](https://www.netlify.com/) or [Docker](https://www.docker.com/)
 
 ## Quickstart
 


### PR DESCRIPTION
w/o a protocol, domains sometimes interpreted as relative paths, 
so markdown renderer made it point to `https://github.com/QingWei-Li/notea/blob/main/netlify.com`