### PR TITLE
fix: restore values for 'deleted' and 'shared' meta

### DIFF
--- a/libs/server/meta.ts
+++ b/libs/server/meta.ts
@@ -39,9 +39,9 @@ export function metaToJson(metaData?: Record<string, string>) {
           meta[key] = strValue
         }
       } else if (key === 'deleted') {
-        meta[key] = NOTE_DELETED.NORMAL
+        meta[key] = value ? strDecompress(value) : NOTE_DELETED.NORMAL
       } else if (key === 'shared') {
-        meta[key] = NOTE_SHARED.PRIVATE
+        meta[key] = value ? strDecompress(value) : NOTE_SHARED.PRIVATE
       }
     })
   }


### PR DESCRIPTION
This PR fixes the conversion of the `deleted` and `shared` meta from metadata record to JSON object.

Without this change when a note is deleted it would still appear after a refresh of the notes list.