### PR TITLE
fix: default image zoom not being triggerable

### DIFF
--- a/components/editor/editor.tsx
+++ b/components/editor/editor.tsx
@@ -86,6 +86,10 @@ const Editor: FC<EditorProps> = ({ readOnly }) => {
         .ProseMirror a:not(.bookmark) {
           text-decoration: underline;
         }
+
+        .ProseMirror .image .ProseMirror-selectednode img {
+          pointer-events: unset;
+        }
       `}</style>
     </>
   )


### PR DESCRIPTION
As far as I can see another theme library (likely Mui) was disabling the default image zoom functionality? The same seems to be happening with code syntax highlighting (rich-markdown-editor [should have dark mode syntax highlighting](https://github.com/outline/rich-markdown-editor/pull/50)). Do you have any idea where these overrides are coming from? 

| image zoom | code syntax highlighting |
|---|---|
| ![image](https://user-images.githubusercontent.com/2472626/131249325-a53e2e49-2521-4dc6-b127-7e941ce4823e.png) | ![image](https://user-images.githubusercontent.com/2472626/131249630-8a3410be-9b3f-4fd9-a4a6-05e72e2066d3.png) |

## Preview of fix

https://user-images.githubusercontent.com/2472626/131249280-9fb50aae-5ff3-48f8-b11d-8c31d039a858.mp4
